### PR TITLE
Improve logging control and reduce logger re-creation

### DIFF
--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -24,6 +24,17 @@ pub struct Agent {
     #[serde(default, rename = "enable_debug")]
     pub debug: bool,
 
+    /// The slog log level will be applied to agent.
+    /// Possible values are:
+    /// - trace
+    /// - debug
+    /// - info
+    /// - warn
+    /// - error
+    /// - critical
+    #[serde(default)]
+    pub slog_level: String,
+
     /// Enable agent tracing.
     ///
     /// If enabled, the agent will generate OpenTelemetry trace spans.
@@ -88,6 +99,7 @@ impl std::default::Default for Agent {
     fn default() -> Self {
         Self {
             debug: true,
+            slog_level: "debug".to_string(),
             enable_tracing: false,
             debug_console_enabled: false,
             server_port: DEFAULT_AGENT_VSOCK_PORT,

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -379,6 +379,17 @@ pub struct DebugInfo {
     #[serde(default)]
     pub enable_debug: bool,
 
+    /// The slog log level will be applied to hypervisor.
+    /// Possible values are:
+    /// - trace
+    /// - debug
+    /// - info
+    /// - warn
+    /// - error
+    /// - critical
+    #[serde(default)]
+    pub slog_level: String,
+
     /// Enable dumping information about guest page structures if true.
     #[serde(default)]
     pub guest_memory_dump_paging: bool,

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -33,6 +33,17 @@ pub struct Runtime {
     #[serde(default, rename = "enable_debug")]
     pub debug: bool,
 
+    /// The slog level will be applied to runtimes.
+    /// Possible values are:
+    /// - trace
+    /// - debug
+    /// - info
+    /// - warn
+    /// - error
+    /// - critical
+    #[serde(default)]
+    pub slog_level: String,
+
     /// Enabled experimental feature list, format: ["a", "b"].
     ///
     /// Experimental features are features not stable enough for production, they may break

--- a/src/libs/logging/Cargo.toml
+++ b/src/libs/logging/Cargo.toml
@@ -18,6 +18,8 @@ slog-json = "2.4.0"
 slog-term = "2.9.0"
 slog-async = "2.7.0"
 slog-scope = "4.4.0"
+lazy_static = "1.3.0"
+arc-swap = "1.5.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -1773,6 +1773,8 @@ dependencies = [
 name = "logging"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
+ "lazy_static",
  "serde_json",
  "slog",
  "slog-async",

--- a/src/runtime-rs/crates/agent/src/kata/agent.rs
+++ b/src/runtime-rs/crates/agent/src/kata/agent.rs
@@ -8,10 +8,15 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use tracing::instrument;
 use ttrpc::context as ttrpc_ctx;
+use slog::Logger;
 
 use kata_types::config::Agent as AgentConfig;
 
 use crate::{kata::KataAgent, Agent, AgentManager, HealthService};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 /// millisecond to nanosecond
 const MILLISECOND_TO_NANOSECOND: i64 = 1_000_000;

--- a/src/runtime-rs/crates/agent/src/kata/mod.rs
+++ b/src/runtime-rs/crates/agent/src/kata/mod.rs
@@ -17,8 +17,13 @@ use kata_types::config::Agent as AgentConfig;
 use protocols::{agent_ttrpc_async as agent_ttrpc, health_ttrpc_async as health_ttrpc};
 use tokio::sync::RwLock;
 use ttrpc::asynchronous::Client;
+use slog::Logger;
 
 use crate::{log_forwarder::LogForwarder, sock};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 // https://github.com/firecracker-microvm/firecracker/blob/master/docs/vsock.md
 #[derive(Debug, Default)]

--- a/src/runtime-rs/crates/agent/src/log_forwarder.rs
+++ b/src/runtime-rs/crates/agent/src/log_forwarder.rs
@@ -6,8 +6,13 @@
 
 use anyhow::Result;
 use tokio::io::{AsyncBufReadExt, BufReader};
+use slog::Logger;
 
 use crate::sock;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 // https://github.com/slog-rs/slog/blob/master/src/lib.rs#L2082
 const LOG_LEVEL_TRACE: &str = "TRCE";

--- a/src/runtime-rs/crates/agent/src/sock/hybrid_vsock.rs
+++ b/src/runtime-rs/crates/agent/src/sock/hybrid_vsock.rs
@@ -12,8 +12,13 @@ use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
     net::UnixStream,
 };
+use slog::Logger;
 
 use super::{ConnectConfig, Sock, Stream};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 #[derive(Debug, PartialEq)]
 pub struct HybridVsock {

--- a/src/runtime-rs/crates/agent/src/sock/mod.rs
+++ b/src/runtime-rs/crates/agent/src/sock/mod.rs
@@ -8,6 +8,10 @@ mod hybrid_vsock;
 pub use hybrid_vsock::HybridVsock;
 mod vsock;
 pub use vsock::Vsock;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 use std::{
     pin::Pin,
@@ -25,6 +29,7 @@ use tokio::{
     net::UnixStream,
 };
 use url::Url;
+use slog::Logger;
 
 const VSOCK_SCHEME: &str = "vsock";
 const HYBRID_VSOCK_SCHEME: &str = "hvsock";

--- a/src/runtime-rs/crates/agent/src/sock/vsock.rs
+++ b/src/runtime-rs/crates/agent/src/sock/vsock.rs
@@ -13,8 +13,13 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use nix::sys::socket::{connect, socket, AddressFamily, SockFlag, SockType, VsockAddr};
 use tokio::net::UnixStream;
+use slog::Logger;
 
 use super::{ConnectConfig, Sock, Stream};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 #[derive(Debug, PartialEq)]
 pub struct Vsock {

--- a/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
@@ -9,11 +9,16 @@ use std::{collections::HashMap, sync::Arc};
 use anyhow::{anyhow, Context, Result};
 use kata_sys_util::rand::RandomBytes;
 use tokio::sync::{Mutex, RwLock};
+use slog::Logger;
 
 use crate::{
     vhost_user_blk::VhostUserBlkDevice, BlockConfig, BlockDevice, HybridVsockDevice, Hypervisor,
     NetworkDevice, VfioDevice, VhostUserConfig, KATA_BLK_DEV_TYPE, KATA_MMIO_BLK_DEV_TYPE,
     KATA_NVDIMM_DEV_TYPE, VIRTIO_BLOCK_MMIO, VIRTIO_BLOCK_PCI, VIRTIO_PMEM,
+};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
 };
 
 use super::{

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
@@ -19,12 +19,17 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use lazy_static::lazy_static;
 use path_clean::PathClean;
+use slog::Logger;
 
 use crate::{
     device::{hypervisor, Device, DeviceType},
     PciPath, PciSlot,
 };
 use kata_sys_util::fs::get_base_name;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 pub const SYS_BUS_PCI_DRIVER_PROBE: &str = "/sys/bus/pci/drivers_probe";
 pub const SYS_BUS_PCI_DEVICES: &str = "/sys/bus/pci/devices";

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -10,6 +10,7 @@ use crate::{
     DEV_HUGEPAGES, HUGETLBFS, HUGE_SHMEM, HYPERVISOR_DRAGONBALL, SHMEM,
 };
 use anyhow::{anyhow, Context, Result};
+use slog::Logger;
 use async_trait::async_trait;
 use dragonball::{
     api::v1::{BootSourceConfig, VcpuResizeInfo},
@@ -23,6 +24,10 @@ use kata_types::{
         hypervisor::{HugePageType, Hypervisor as HypervisorConfig},
         KATA_PATH,
     },
+};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
 };
 use nix::mount::MsFlags;
 use persist::sandbox_persist::Persist;

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -7,6 +7,7 @@
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Context, Result};
+use slog::Logger;
 use dbs_utils::net::MacAddr;
 use dragonball::{
     api::v1::{
@@ -20,6 +21,10 @@ use super::DragonballInner;
 use crate::{
     device::DeviceType, HybridVsockConfig, NetworkConfig, ShareFsDeviceConfig, ShareFsMountConfig,
     ShareFsMountType, ShareFsOperation, VfioBusMode, VfioDevice, VmmState, JAILER_ROOT,
+};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
 };
 
 const MB_TO_B: u32 = 1024 * 1024;

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
@@ -10,7 +10,12 @@ use std::{
 };
 
 use anyhow::{Context, Ok, Result};
+use slog::Logger;
 use kata_types::capabilities::Capabilities;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 use super::inner::DragonballInner;
 use crate::{

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
+use slog::Logger;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use dragonball::{
     api::v1::{
@@ -25,6 +26,10 @@ use dragonball::{
 use nix::sched::{setns, CloneFlags};
 use seccompiler::BpfProgram;
 use vmm_sys_util::eventfd::EventFd;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 use crate::ShareFsOperation;
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -4,9 +4,14 @@
 //
 
 use anyhow::Result;
+use slog::Logger;
 
 use crate::{HypervisorConfig, VcpuThreadIds};
 use kata_types::capabilities::{Capabilities, CapabilityBits};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 const VSOCK_SCHEME: &str = "vsock";
 const VSOCK_AGENT_CID: u32 = 3;

--- a/src/runtime-rs/crates/resource/src/cpu_mem/cpu.rs
+++ b/src/runtime-rs/crates/resource/src/cpu_mem/cpu.rs
@@ -12,9 +12,14 @@ use std::{
 };
 
 use agent::{Agent, OnlineCPUMemRequest};
+use slog::Logger;
 use anyhow::{Context, Ok, Result};
 use hypervisor::Hypervisor;
 use kata_types::{config::TomlConfig, cpu::LinuxContainerCpuResources};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use oci::LinuxCpu;
 use tokio::sync::RwLock;
 

--- a/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
+++ b/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
@@ -7,10 +7,15 @@
 use std::convert::TryFrom;
 
 use anyhow::{Context, Result};
+use slog::Logger;
 
 use kata_types::{
     annotations::Annotation, config::TomlConfig, container::ContainerType,
     cpu::LinuxContainerCpuResources, k8s::container_type,
+};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
 };
 
 // initial resource that InitialSizeManager needs, this is the spec for the

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -8,6 +8,7 @@ use std::{sync::Arc, thread};
 
 use agent::{types::Device, Agent, Storage};
 use anyhow::{anyhow, Context, Ok, Result};
+use slog::Logger;
 use async_trait::async_trait;
 use hypervisor::{
     device::{
@@ -19,6 +20,10 @@ use hypervisor::{
 };
 use kata_types::config::TomlConfig;
 use kata_types::mount::Mount;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use oci::{Linux, LinuxCpu, LinuxResources};
 use persist::sandbox_persist::Persist;
 use tokio::{runtime, sync::RwLock};

--- a/src/runtime-rs/crates/resource/src/network/dan.rs
+++ b/src/runtime-rs/crates/resource/src/network/dan.rs
@@ -21,10 +21,15 @@ use std::sync::Arc;
 
 use agent::IPFamily;
 use anyhow::{anyhow, Context, Result};
+use slog::Logger;
 use async_trait::async_trait;
 use hypervisor::device::device_manager::DeviceManager;
 use hypervisor::Hypervisor;
 use kata_types::config::TomlConfig;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use scopeguard::defer;
 use serde::{Deserialize, Serialize};
 use tokio::fs;

--- a/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_link.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_link.rs
@@ -8,8 +8,13 @@ use std::convert::TryFrom;
 
 use agent::{ARPNeighbor, IPAddress, IPFamily, Interface, Route};
 use anyhow::{Context, Result};
+use slog::Logger;
 use async_trait::async_trait;
 use futures::stream::TryStreamExt;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use netlink_packet_route::{
     self, neighbour::NeighbourMessage, nlas::neighbour::Nla, route::RouteMessage,
 };

--- a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
@@ -14,9 +14,14 @@ use std::{
 
 use super::endpoint::endpoint_persist::EndpointState;
 use anyhow::{anyhow, Context, Result};
+use slog::Logger;
 use async_trait::async_trait;
 use futures::stream::TryStreamExt;
 use hypervisor::{device::device_manager::DeviceManager, Hypervisor};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use netns_rs::get_from_path;
 use scopeguard::defer;
 use tokio::sync::RwLock;

--- a/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
@@ -12,7 +12,12 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use slog::Logger;
 use nix::ioctl_write_ptr;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 use super::macros::{get_name, set_name};
 

--- a/src/runtime-rs/crates/resource/src/network/utils/netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/netns.rs
@@ -7,9 +7,14 @@
 use std::{fs::File, os::unix::io::AsRawFd};
 
 use anyhow::{Context, Result};
+use slog::Logger;
 use nix::sched::{setns, CloneFlags};
 use nix::unistd::{getpid, gettid};
 use rand::Rng;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 pub struct NetnsGuard {
     old_netns: Option<File>,

--- a/src/runtime-rs/crates/resource/src/rootfs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/mod.rs
@@ -8,10 +8,15 @@ mod nydus_rootfs;
 mod share_fs_rootfs;
 use agent::Storage;
 use anyhow::{anyhow, Context, Result};
+use slog::Logger;
 use async_trait::async_trait;
 use kata_types::mount::Mount;
 mod block_rootfs;
 use hypervisor::{device::device_manager::DeviceManager, Hypervisor};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use std::{sync::Arc, vec::Vec};
 use tokio::sync::RwLock;
 

--- a/src/runtime-rs/crates/resource/src/rootfs/nydus_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/nydus_rootfs.rs
@@ -15,9 +15,14 @@ use crate::{
 };
 use agent::Storage;
 use anyhow::{anyhow, Context, Result};
+use slog::Logger;
 use async_trait::async_trait;
 use hypervisor::{device::device_manager::DeviceManager, Hypervisor};
 use kata_types::mount::{Mount, NydusExtraOptions};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use tokio::sync::RwLock;
 
 // Used for nydus rootfs

--- a/src/runtime-rs/crates/resource/src/share_fs/sandbox_bind_mounts.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/sandbox_bind_mounts.rs
@@ -19,10 +19,15 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
+use slog::Logger;
 
 use super::utils::{do_get_host_path, mkdir_with_permissions};
 use kata_sys_util::{fs::get_base_name, mount};
 use kata_types::mount::{SANDBOX_BIND_MOUNTS_DIR, SANDBOX_BIND_MOUNTS_RO, SANDBOX_BIND_MOUNTS_RW};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use nix::mount::MsFlags;
 
 #[derive(Clone, Default, Debug)]

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
@@ -7,6 +7,7 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use slog::Logger;
 use hypervisor::{
     device::{
         driver::{
@@ -18,6 +19,10 @@ use hypervisor::{
     Hypervisor, ShareFsDeviceConfig,
 };
 use kata_sys_util::mount;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use nix::mount::MsFlags;
 
 use super::{utils, PASSTHROUGH_FS_DIR};

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
@@ -12,9 +12,14 @@ use crate::share_fs::share_virtio_fs::{
 use crate::share_fs::{KATA_GUEST_SHARE_DIR, VIRTIO_FS};
 use agent::Storage;
 use anyhow::{anyhow, Context, Result};
+use slog::Logger;
 use async_trait::async_trait;
 use hypervisor::Hypervisor;
 use kata_types::config::hypervisor::SharedFsInfo;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
     process::{Child, Command},

--- a/src/runtime-rs/crates/resource/src/volume/default_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/default_volume.rs
@@ -8,8 +8,12 @@ use hypervisor::device::device_manager::DeviceManager;
 use tokio::sync::RwLock;
 
 use anyhow::Result;
+use slog::Logger;
 use async_trait::async_trait;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use super::Volume;
 
 #[derive(Debug)]

--- a/src/runtime-rs/crates/resource/src/volume/mod.rs
+++ b/src/runtime-rs/crates/resource/src/volume/mod.rs
@@ -20,8 +20,13 @@ use spdk_volume::is_spdk_volume;
 use std::{sync::Arc, vec::Vec};
 
 use anyhow::{Context, Result};
+use slog::Logger;
 use async_trait::async_trait;
 use tokio::sync::RwLock;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 use self::hugepage::{get_huge_page_limits_map, get_huge_page_option};
 use crate::{share_fs::ShareFs, volume::block_volume::is_block_volume};

--- a/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
@@ -15,9 +15,14 @@ use std::{
 
 use agent::Agent;
 use anyhow::{anyhow, Context, Result};
+use slog::Logger;
 use async_trait::async_trait;
 use hypervisor::device::device_manager::DeviceManager;
 use tokio::sync::RwLock;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 use super::Volume;
 use crate::share_fs::{MountedInfo, ShareFs, ShareFsVolumeConfig};

--- a/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
@@ -7,9 +7,14 @@
 use std::path::Path;
 
 use anyhow::Result;
+use slog::Logger;
 use async_trait::async_trait;
 use hypervisor::device::device_manager::DeviceManager;
 use tokio::sync::RwLock;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 use super::Volume;
 use crate::share_fs::DEFAULT_KATA_GUEST_SANDBOX_DIR;

--- a/src/runtime-rs/crates/runtimes/src/shim_mgmt/handlers.rs
+++ b/src/runtime-rs/crates/runtimes/src/shim_mgmt/handlers.rs
@@ -10,11 +10,16 @@
 use crate::shim_metrics::get_shim_metrics;
 use agent::ResizeVolumeRequest;
 use anyhow::{anyhow, Context, Result};
+use slog::Logger;
 use common::Sandbox;
 use hyper::{Body, Method, Request, Response, StatusCode};
 use std::sync::Arc;
 use url::Url;
 
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use shim_interface::shim_mgmt::{
     AGENT_URL, DIRECT_VOLUME_PATH_KEY, DIRECT_VOLUME_RESIZE_URL, DIRECT_VOLUME_STATS_URL,
     IP6_TABLE_URL, IP_TABLE_URL, METRICS_URL,

--- a/src/runtime-rs/crates/runtimes/src/shim_mgmt/server.rs
+++ b/src/runtime-rs/crates/runtimes/src/shim_mgmt/server.rs
@@ -14,11 +14,16 @@
 use std::{fs, path::Path, sync::Arc};
 
 use anyhow::{Context, Result};
+use slog::Logger;
 use common::Sandbox;
 use hyper::{server::conn::Http, service::service_fn};
 use shim_interface::{mgmt_socket_addr, shim_mgmt::ERR_NO_SHIM_SERVER};
 use tokio::net::UnixListener;
 
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use super::handlers::handler_mux;
 
 /// The shim management server instance

--- a/src/runtime-rs/crates/runtimes/src/tracer.rs
+++ b/src/runtime-rs/crates/runtimes/src/tracer.rs
@@ -8,12 +8,17 @@ use std::cmp::min;
 use std::sync::Arc;
 
 use anyhow::Result;
+use slog::Logger;
 use lazy_static::lazy_static;
 use opentelemetry::global;
 use opentelemetry::runtime::Tokio;
 use tracing::{span, subscriber::NoSubscriber, Span, Subscriber};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::Registry;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 const DEFAULT_JAEGER_URL: &str = "http://localhost:14268/api/traces";
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use agent::Agent;
+use slog::Logger;
 use anyhow::{anyhow, Context, Result};
 use common::{
     error::Error,
@@ -17,6 +18,10 @@ use common::{
     },
 };
 use kata_sys_util::k8s::update_ephemeral_storage_type;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 use oci::{LinuxResources, Process as OCIProcess};
 use resource::{ResourceManager, ResourceUpdateOp};

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -13,9 +13,14 @@ use common::{
     types::{ContainerID, ContainerProcess, ProcessExitStatus, ProcessStatus, ProcessType},
 };
 use hypervisor::device::device_manager::DeviceManager;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use nix::sys::signal::Signal;
 use oci::LinuxResources;
 use resource::{rootfs::Rootfs, volume::Volume};
+use slog::Logger;
 use tokio::sync::RwLock;
 
 use crate::container_manager::logger_with_process;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/shim_io.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/shim_io.rs
@@ -17,10 +17,15 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use nix::{
     fcntl::{self, OFlag},
     sys::stat::Mode,
 };
+use slog::Logger;
 use tokio::{
     fs::OpenOptions,
     io::{AsyncRead, AsyncWrite},

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
@@ -23,10 +23,15 @@ use hypervisor::Hypervisor;
 use oci::Process as OCIProcess;
 use resource::network::NetnsGuard;
 use resource::ResourceManager;
+use slog::Logger;
 use tokio::sync::RwLock;
 use tracing::instrument;
 
 use kata_sys_util::hooks::HookStates;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 use super::{logger_with_process, Container};
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/mod.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/mod.rs
@@ -14,6 +14,11 @@ pub use manager::VirtContainerManager;
 mod process;
 
 use common::types::ContainerProcess;
+use slog::Logger;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 fn logger_with_process(container_process: &ContainerProcess) -> slog::Logger {
     sl!().new(o!("container_id" => container_process.container_id.container_id.clone(), "exec_id" => container_process.exec_id.clone()))

--- a/src/runtime-rs/crates/runtimes/virt_container/src/health_check.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/health_check.rs
@@ -8,7 +8,12 @@ use std::sync::Arc;
 
 use agent::Agent;
 use anyhow::Context;
+use slog::Logger;
 use tokio::sync::{mpsc, Mutex};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 /// monitor check interval 30s
 const HEALTH_CHECK_TIMER_INTERVAL: u64 = 30;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -18,6 +18,11 @@ use hypervisor::{dragonball::Dragonball, BlockConfig, Hypervisor, HYPERVISOR_DRA
 use hypervisor::{utils::get_hvsock_path, HybridVsockConfig, DEFAULT_GUEST_VSOCK_CID};
 use kata_sys_util::hooks::HookStates;
 use kata_types::config::TomlConfig;
+use slog::Logger;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use persist::{self, sandbox_persist::Persist};
 use resource::manager::ManagerArgs;
 use resource::network::{dan_config_path, DanNetworkConfig, NetworkConfig, NetworkWithNetNsConfig};

--- a/src/runtime-rs/crates/service/src/manager.rs
+++ b/src/runtime-rs/crates/service/src/manager.rs
@@ -18,7 +18,12 @@ use containerd_shim_protos::{
     shim_async,
 };
 use kata_types::config::KATA_PATH;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use runtimes::RuntimeHandlerManager;
+use slog::Logger;
 use tokio::{
     io::AsyncWriteExt,
     process::Command,

--- a/src/runtime-rs/crates/service/src/task_service.rs
+++ b/src/runtime-rs/crates/service/src/task_service.rs
@@ -12,9 +12,14 @@ use std::{
 use async_trait::async_trait;
 use common::types::{Request, Response};
 use containerd_shim_protos::{api, shim_async};
+use slog::Logger;
 use ttrpc::{self, r#async::TtrpcContext};
 
 use runtimes::RuntimeHandlerManager;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 pub(crate) struct TaskService {
     handler: Arc<RuntimeHandlerManager>,

--- a/src/runtime-rs/crates/shim/src/logger.rs
+++ b/src/runtime-rs/crates/shim/src/logger.rs
@@ -5,10 +5,14 @@
 //
 
 use std::os::unix::fs::OpenOptionsExt;
-
-use anyhow::{Context, Result};
+use std::sync::Arc;
 
 use crate::Error;
+use anyhow::{Context, Result};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 pub(crate) fn set_logger(path: &str, sid: &str, is_debug: bool) -> Result<slog_async::AsyncGuard> {
     let fifo = std::fs::OpenOptions::new()
@@ -36,6 +40,32 @@ pub(crate) fn set_logger(path: &str, sid: &str, is_debug: bool) -> Result<slog_a
         log::Level::Info
     };
     slog_stdlog::init_with_level(level).context(format!("init with level {}", level))?;
+
+    VMM_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "hypervisor")),
+    ));
+    VMM_DRAGONBALL_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "vmm-dragonball")),
+    ));
+
+    AGENT_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "agent")),
+    ));
+    RESOURCE_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "resource")),
+    ));
+    RUNTIMES_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "runtimes")),
+    ));
+    VIRT_CONTAINER_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "virt-container")),
+    ));
+    SERVICE_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "service")),
+    ));
+    SHIM_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "shim")),
+    ));
 
     Ok(async_guard)
 }

--- a/src/runtime-rs/crates/shim/src/panic_hook.rs
+++ b/src/runtime-rs/crates/shim/src/panic_hook.rs
@@ -7,6 +7,11 @@
 use std::{boxed::Box, fs::OpenOptions, io::Write, ops::Deref};
 
 use backtrace::Backtrace;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 
 const KMESG_DEVICE: &str = "/dev/kmsg";
 

--- a/src/runtime-rs/crates/shim/src/shim_delete.rs
+++ b/src/runtime-rs/crates/shim/src/shim_delete.rs
@@ -8,8 +8,13 @@ use anyhow::{Context, Result};
 use containerd_shim_protos::api;
 use kata_sys_util::spec::{get_bundle_path, get_container_type, load_oci_spec};
 use kata_types::container::ContainerType;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use nix::{sys::signal::kill, sys::signal::SIGKILL, unistd::Pid};
 use protobuf::Message;
+use slog::Logger;
 use std::{fs, path::Path};
 
 use crate::{shim::ShimExecutor, Error};

--- a/src/runtime-rs/crates/shim/src/shim_run.rs
+++ b/src/runtime-rs/crates/shim/src/shim_run.rs
@@ -8,6 +8,11 @@ use std::os::unix::io::RawFd;
 
 use anyhow::{Context, Result};
 use kata_sys_util::spec::get_bundle_path;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 
 use crate::{
     core_sched, logger,


### PR DESCRIPTION
By modifying RuntimeLevelFilter drain to improve logging control, enabling isolation of change effect of the loggers between components.